### PR TITLE
Unrolled pathway

### DIFF
--- a/pathway/pathways.py
+++ b/pathway/pathways.py
@@ -71,6 +71,7 @@ class Step(object):
 
 class Pathway(object):
     title = ""
+    slug = ""
 
     # any iterable will do, this should be overridden
     steps = []
@@ -98,7 +99,14 @@ class Pathway(object):
         if not IMPORTED_FROM_APPS:
             import_from_apps()
 
-        return klass.__subclasses__()
+        return _itersubclasses(klass)
+
+    @classmethod
+    def get_template_names(klass):
+        names = ['pathway/pathway_detail.html']
+        if klass.slug:
+            names.insert(0, 'pathway/{0}.html'.format(klass.slug))
+        return names
 
     def save_url(self):
         return reverse("pathway_create", kwargs=dict(name=self.slug))
@@ -113,7 +121,7 @@ class Pathway(object):
 
         return all_steps
 
-    def get_steps_info(self):
+    def to_dict(self):
         # the dict we json to send over
         # in theory it takes a list of either models or steps
         # in reality you can swap out steps for anything with a todict method
@@ -133,3 +141,15 @@ class Pathway(object):
             title=self.title,
             save_url=self.save_url()
         )
+
+
+class UnrolledPathway(Pathway):
+    """
+    An unrolled pathway will display all of it's forms
+    at once, rather than as a set of steps.
+    """
+
+    def to_dict(self):
+        as_dict = super(UnrolledPathway, self).to_dict()
+        as_dict['unrolled'] = True
+        return as_dict

--- a/pathway/pathways.py
+++ b/pathway/pathways.py
@@ -3,10 +3,12 @@ from copy import copy
 
 from django.core.urlresolvers import reverse
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 from django.utils.text import slugify
 from django.http import Http404
 
+from opal.core.subrecords import singleton_subrecords
+from opal.models import Patient, Episode, EpisodeSubrecord
 from opal.utils import stringport
 from opal.utils import _itersubclasses
 
@@ -48,25 +50,42 @@ class Step(object):
         result.update(self.other_args)
         return result
 
-    def save(self, episode_id, data, user):
+    def save(self, data, user, episode=None, new_episode=True):
         if not self.model:
             return
 
         update_info = copy(data.get(self.model.get_api_name(), None))
-
         if not update_info or not any(update_info.itervalues()):
             return
 
-        update_info["episode_id"] = episode_id
+        if 'id' in update_info:
+            instance = self.model.objects.get(id=update_info['id'])
+        else:
+            if issubclass(self.model, EpisodeSubrecord):
+                instance = self.model(episode=episode)
+            else:
+                instance = self.model(patient=episode.patient)
 
         if self.model._is_singleton:
-            new_model = self.model.objects.get(episode_id=episode_id)
-        else:
-            new_model = self.model()
+            if issubclass(self.model, EpisodeSubrecord):
+                instance = self.model.objects.get(episode=episode)
+            else:
+                instance = self.model.objects.get(patient=episode.patient)
 
-        new_model.update_from_dict(update_info, user)
-        new_model.save()
-        return new_model
+            if new_episode:
+                update_info['consistency_token'] = instance.consistency_token
+
+        instance.update_from_dict(update_info, user)
+        return instance
+
+class RedirectsToPatientMixin(object):
+    def redirect_url(self, episode):
+        return "/#/patient/{0}".format(episode.patient.id)
+
+
+class RedirectsToEpisodeMixin(object):
+    def redirect_url(self, episode):
+        return "/#/patient/{0}/{1}".format(episode.patient.id, episode.id)
 
 
 class Pathway(object):
@@ -75,6 +94,15 @@ class Pathway(object):
 
     # any iterable will do, this should be overridden
     steps = []
+
+    def __init__(self, episode_id=None):
+        self.episode_id = episode_id
+
+    @property
+    def episode(self):
+        if self.episode_id is None:
+            return None
+        return Episode.objects.get(id=self.episode_id)
 
     @property
     def slug(self):
@@ -110,6 +138,46 @@ class Pathway(object):
 
     def save_url(self):
         return reverse("pathway_create", kwargs=dict(name=self.slug))
+
+    def redirect_url(save, episode):
+        return None
+
+
+    def _save_for_new_patient(self, patient, data, user):
+        patient.update_from_demographics_dict(data['demographics'], user)
+
+        episode = patient.create_episode()
+
+        for step in self.get_steps():
+            saved = step.save(data, user, episode=episode, new_episode=True)
+        return episode
+
+    def _update_episode(self, episode, data, user):
+        for step in self.get_steps():
+            saved = step.save(data, user, episode=episode)
+        return episode
+
+
+    def save(self, data, user):
+        with transaction.atomic():
+            if self.episode_id:
+                return self._update_episode(self.episode, data, user)
+
+            demographics = data.get("demographics", None)
+
+            if demographics is None:
+                raise ValueError('We need either demographics or an episode id to save to a patient')
+
+            hospital_number = demographics["hospital_number"]
+
+            patient, created = Patient.objects.get_or_create(
+                demographics__hospital_number=hospital_number
+            )
+
+            if created:
+                return self._save_for_new_patient(patient, data, user)
+            else:
+                return self._create_episode_then_save(patient, data, user)
 
     def get_steps(self):
         all_steps = []

--- a/pathway/static/js/pathway/app.js
+++ b/pathway/static/js/pathway/app.js
@@ -43,6 +43,8 @@ app.config(function($routeProvider){
                 pathway: function(pathwayLoader){ return pathwayLoader(); },
             		options: function(Options) { return Options; },
             },
-            templateUrl: '/pathway/templates/pathwaydetail.html'
+            templateUrl: function(params){
+                return '/pathway/templates/' + params.pathway + '/detail.html'
+            }
         });
 });

--- a/pathway/static/js/pathway/app.js
+++ b/pathway/static/js/pathway/app.js
@@ -37,11 +37,17 @@ app.config(function($routeProvider){
             resolve: {},
             templateUrl: '/pathway/templates/pathwaydetail.html'
         })
-        .when('/:pathway', {
+        .when('/:pathway/:episode_id?', {
             controller: 'PathwayController',
             resolve: {
                 pathway: function(pathwayLoader){ return pathwayLoader(); },
-            		options: function(Options) { return Options; },
+            	options: function(Options) { return Options; },
+                episode: function($route, episodeLoader){
+                    if(!$route.current.params.episode_id){
+                        return null;
+                    }
+                    return episodeLoader($route.current.params.episode_id);
+                }
             },
             templateUrl: function(params){
                 return '/pathway/templates/' + params.pathway + '/detail.html'

--- a/pathway/static/js/pathway/controllers/pathway.js
+++ b/pathway/static/js/pathway/controllers/pathway.js
@@ -1,9 +1,12 @@
 angular.module('opal.pathway.controllers').controller(
     'PathwayController', function(
-        $scope, $http, multistage, pathway, options, $window, Item, $rootScope
+        $scope, $http, multistage, pathway, options, $window, Item, $rootScope, episode
       ){
         "use strict";
         pathway.appendTo = ".appendTo";
+        if(episode){
+            pathway.episode = episode;
+        }
 
         pathway.finish = function(createdScope, steps){
             _.each(steps, function(step){
@@ -18,13 +21,17 @@ angular.module('opal.pathway.controllers').controller(
                 return item.castToType(val);
             });
 
-            $http.post(pathway.save_url, toSave)
+            var endpoint = pathway.save_url
+            if(episode){
+                endpoint += episode.id
+            }
+
+            $http.post(endpoint, toSave)
             .then(
                function(response){
-                   var target = "/#/patient/" 
-                   target += response.data.patient_id 
-                   target += "/" + response.data.episode_id;
-                   $window.location.href = target
+                   if(response.data.redirect_url){
+                       $window.location.href = response.data.redirect_url
+                   }
              }, function(error){
                  alert("unable to save patient");
              });

--- a/pathway/static/js/pathway/controllers/unrolled_pathway.js
+++ b/pathway/static/js/pathway/controllers/unrolled_pathway.js
@@ -1,0 +1,34 @@
+angular.module('opal.pathway.controllers').controller(
+    'PathwayController', function(
+        $scope, $http, multistage, pathway, options, $window, Item, $rootScope
+      ){
+        "use strict";
+        pathway.appendTo = ".appendTo";
+
+        pathway.finish = function(createdScope, steps){
+            _.each(steps, function(step){
+                if(step.controller.toSave){
+                    step.controller.toSave(createdScope);
+                }
+            });
+
+            // cast the item to the fields for the server
+            var toSave = _.mapObject(createdScope.editing, function(val, key){
+                var item = new Item(val, {}, $rootScope.fields[key]);
+                return item.castToType(val);
+            });
+
+            $http.post(pathway.save_url, toSave)
+            .then(
+               function(response){
+                   var target = "/#/patient/"
+                   target += response.data.patient_id
+                   target += "/" + response.data.episode_id;
+                   $window.location.href = target
+             }, function(error){
+                 alert("unable to save patient");
+             });
+        };
+        multistage.open(pathway);
+    }
+);

--- a/pathway/static/js/pathway/services/multi_stage_form.js
+++ b/pathway/static/js/pathway/services/multi_stage_form.js
@@ -14,7 +14,10 @@ angular.module('opal.multistage')
 })
 .provider('multistage', function(){
     var multistageProvider = {
-        $get: ['$q', '$rootScope', '$document', '$templateRequest', '$compile', '$controller', 'Options',
+        $get: [
+            '$q', '$rootScope', '$document', '$templateRequest',
+            '$compile', '$controller', 'Options',
+
         function($q, $rootScope, $document, $templateRequest, $compile, $controller, Options){
             function getTemplatePromise(options) {
                  return options.template ? $q.when(options.template) :
@@ -46,7 +49,12 @@ angular.module('opal.multistage')
                         // first deal with referal
                         // needs to be overridden;
                     },
-                    template_url: "/pathway/templates/pathway/form_base.html",
+                    template_url: function(){
+                        if(multistageOptions.unrolled){
+                            return "/templates/pathway/unrolled_form_base.html"
+                        }
+                        return "/templates/pathway/form_base.html"
+                    },
                     goNext: function(){
                       if(multistageOptions.hasNext()){
                         newScope.currentIndex = multistageOptions.next(newScope.currentIndex, newScope.currentStep);
@@ -90,7 +98,12 @@ angular.module('opal.multistage')
 
                 var loadInStep = function(step, index){
                     getTemplatePromise(step).then(function(loadedHtml){
+                        if(multistageOptions.unrolled){
+                            unrolled_titles = "<h4>[[ steps["+index+"].title ]]</h4>";
+                            loadedHtml = unrolled_titles + loadedHtml;
+                        }else{
                         loadedHtml = "<div ng-if='currentIndex == " + index + "'>" + loadedHtml + "</div>";
+                        }
                         var result = $compile(loadedHtml)(newScope);
                         $(multistageOptions.appendTo).find(".to_append").append(result);
                     });

--- a/pathway/static/js/pathway/services/multi_stage_form.js
+++ b/pathway/static/js/pathway/services/multi_stage_form.js
@@ -57,7 +57,8 @@ angular.module('opal.multistage')
                     },
                     goNext: function(){
                       if(multistageOptions.hasNext()){
-                        newScope.currentIndex = multistageOptions.next(newScope.currentIndex, newScope.currentStep);
+                          newScope.currentIndex = multistageOptions.next(
+                              newScope.currentIndex, newScope.currentStep);
                         newScope.currentStep = multistageOptions.steps[newScope.currentIndex];
                       }
                       else{
@@ -65,8 +66,12 @@ angular.module('opal.multistage')
                       }
                     },
                     goPrevious: function(){
-                      newScope.currentIndex = multistageOptions.previous(newScope.currentIndex, newScope.currentStep);
+                        newScope.currentIndex = multistageOptions.previous(
+                            newScope.currentIndex, newScope.currentStep);
                       newScope.currentStep = multistageOptions.steps[newScope.currentIndex];
+                    },
+                    goToFinish: function(){
+                        multistageOptions.finish(newScope, multistageOptions.steps)
                     }
                 };
 
@@ -99,7 +104,10 @@ angular.module('opal.multistage')
                 var loadInStep = function(step, index){
                     getTemplatePromise(step).then(function(loadedHtml){
                         if(multistageOptions.unrolled){
-                            unrolled_titles = "<h4>[[ steps["+index+"].title ]]</h4>";
+                            unrolled_titles = "<h4 class='text-center content-offset-25'>[[ steps["+index+"].title ]]</h4>";
+                            if(index>0){
+                                unrolled_titles = "<hr>" + unrolled_titles;
+                            }
                             loadedHtml = unrolled_titles + loadedHtml;
                         }else{
                         loadedHtml = "<div ng-if='currentIndex == " + index + "'>" + loadedHtml + "</div>";
@@ -118,6 +126,24 @@ angular.module('opal.multistage')
                 newScope.currentIndex = 0;
                 newScope.numSteps = multistageOptions.steps.length;
                 newScope.editing = {};
+
+                // We were passed in a patient.
+                // Let's make sure we can edit every item for the patient.
+                if(multistageOptions.episode){
+                    _.each(_.keys($rootScope.fields), function(key){
+                        var copies = _.map(
+                            multistageOptions.episode[key],
+                            function(record){
+                                return record.makeCopy();
+                            });
+                        if(copies.length > 0){
+                            newScope.editing[key] = copies[0]
+                        }else{
+                            newScope.editing[key] = {}
+                        }
+                    });
+                }
+
                 newScope.currentStep = newScope.steps[newScope.currentIndex];
                 newScope.stepIndex = function(step){
                     return _.findIndex(newScope.steps, function(someStep){

--- a/pathway/templates/pathway/form_base.html
+++ b/pathway/templates/pathway/form_base.html
@@ -4,9 +4,11 @@
     <h2>
       [[ title ]]
     </h2>
+    {% block process_steps %}
     <div class="pathway-process-steps">
       {% process_steps process_steps="steps" click="clickIcon" show_titles=False active="progress_step.title === currentStep.title" complete="stepIndex(progress_step) < currentIndex" disabled="stepIndex(progress_step) > currentIndex" %}
     </div>
+    {% endblock %}
   </div>
   <div class="panel-body">
     <div class="pathway-process-steps-padding">
@@ -35,6 +37,7 @@
   <div class="panel-footer">
     <div class="row">
       <div class="col-md-8 col-md-push-2">
+        {% block buttons %}
         <button
           ng-disabled="!currentStep.controller.valid(editing)"
           class="btn btn-lg btn-primary float-right"
@@ -52,6 +55,7 @@
             <i class="fa fa-arrow-left"></i> Back
            </button>
          </div>
+        {% endblock %}
      </div>
     </div>
   </div>

--- a/pathway/templates/pathway/form_base.html
+++ b/pathway/templates/pathway/form_base.html
@@ -14,13 +14,15 @@
         <div class="col-md-8 col-md-push-2">
           <div class="panel panel-default">
             <div class="panel-heading">
+              {% block panelheading %}
               <h3>
                 <span ng-show="currentStep.icon">
                 <i class="[[ currentStep.icon ]]"></i>
                 </span>
-                [[ currentStep.title ]] 
+                [[ currentStep.title ]]
                 <small>[[ currentIndex + 1 ]] of [[ numSteps ]]</small>
               </h3>
+              {% endblock %}
             </div>
             <div class="panel-body">
               <div class="to_append"></div>

--- a/pathway/templates/pathway/unrolled_form_base.html
+++ b/pathway/templates/pathway/unrolled_form_base.html
@@ -1,4 +1,11 @@
 {% extends 'pathway/form_base.html' %}
+{% load forms %}
+{% block process_steps %}{% endblock %}
 {% block panelheading %}
   <h3>[[ title ]]</h3>
 {% endblock %}
+  {% block buttons %}
+  <button class="btn btn-primary btn-lg pull-right" ng-click="goToFinish()">
+    Save {% icon "fa-save" %}
+  </button>
+  {% endblock %}

--- a/pathway/templates/pathway/unrolled_form_base.html
+++ b/pathway/templates/pathway/unrolled_form_base.html
@@ -1,0 +1,4 @@
+{% extends 'pathway/form_base.html' %}
+{% block panelheading %}
+  <h3>[[ title ]]</h3>
+{% endblock %}

--- a/pathway/urls.py
+++ b/pathway/urls.py
@@ -8,10 +8,13 @@ from pathway import views
 urlpatterns = patterns(
     '',
     url(r'^pathway/$', views.PathwayIndexView.as_view()),
+
     url(r'^pathway/detail/(?P<name>[a-z_]+)$',
         views.PathwayDetailView.as_view()),
-    url(r'^pathway/templates/(?P<name>[a-z_]+.html)$',
+
+    url(r'^pathway/templates/(?P<name>[a-z_]+)/detail.html$',
         views.PathwayTemplateView.as_view()),
+
     url(r'^pathway/(?P<name>[a-z_]+)/save/',
         views.SavePathway.as_view({'post': 'create'}),
         name="pathway_create")

--- a/pathway/urls.py
+++ b/pathway/urls.py
@@ -15,7 +15,7 @@ urlpatterns = patterns(
     url(r'^pathway/templates/(?P<name>[a-z_]+)/detail.html$',
         views.PathwayTemplateView.as_view()),
 
-    url(r'^pathway/(?P<name>[a-z_]+)/save/',
+    url(r'^pathway/(?P<name>[a-z_]+)/save/(?P<episode_id>[0-9]+)?',
         views.SavePathway.as_view({'post': 'create'}),
         name="pathway_create")
 )

--- a/pathway/views.py
+++ b/pathway/views.py
@@ -44,10 +44,16 @@ class PathwayTemplateView(TemplateView):
 class SavePathway(mixins.CreateModelMixin, viewsets.GenericViewSet):
     def dispatch(self, *args, **kwargs):
         self.name = kwargs.pop('name', 'pathway')
+        self.episode_id = kwargs.get('episode_id', None)
         return super(SavePathway, self).dispatch(*args, **kwargs)
 
-    def create(self, request):
-        pathway = Pathway.get(self.name)()
+    def create(self, request, **kwargs):
+        pathway = Pathway.get(self.name)(episode_id=self.episode_id)
         data = _get_request_data(request)
         episode = pathway.save(data, request.user)
-        return Response({"episode_id": episode.id, "patient_id": episode.patient.id})
+        redirect = pathway.redirect_url(episode)
+        return Response({
+            "episode_id": episode.id,
+            "patient_id": episode.patient.id,
+            "redirect_url": redirect
+        })

--- a/pathway/views.py
+++ b/pathway/views.py
@@ -26,7 +26,7 @@ class PathwayDetailView(LoginRequiredMixin, View):
     def get(self, *args, **kwargs):
         pathway = Pathway.get(kwargs['name'])()
         serialised = _build_json_response(
-            pathway.get_steps_info()
+            pathway.to_dict()
         )
         return serialised
 
@@ -34,10 +34,11 @@ class PathwayDetailView(LoginRequiredMixin, View):
 class PathwayTemplateView(TemplateView):
     def dispatch(self, *args, **kwargs):
         self.name = kwargs.get('name', 'pathway')
+        self.pathway = Pathway.get(self.name)
         return super(PathwayTemplateView, self).dispatch(*args, **kwargs)
 
     def get_template_names(self, *args, **kwargs):
-        return ['pathway/'+self.name, 'pathway/pathway_detail.html']
+        return self.pathway.get_template_names()
 
 
 class SavePathway(mixins.CreateModelMixin, viewsets.GenericViewSet):


### PR DESCRIPTION
* Allows us to have Pathways that are unrolled and display every step on the page at once.
* Pathways have a per episode route that allows you to edit the episode through the worldview of that pathway
* Creates a pathway template hierarchy - e.g. pathway/$slug.html
* Pathway.redirect_url(self, episode) is now a thing you can override
* Uses `opal.views.RawTemplateView` wherever possible 

No, of course that's one logical PR.