### PR TITLE
add an optional pathway-episode argument to set the episode used by t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ Pathways detect when you're opening a pathway from a modal.
 
 You can use a different template for your modal pathway by adding a modal_template_url attribute to your pathway
 
+Pathways ships with a no footer modal template, the same as the normal modal template but it doesn't display the section at the bottom with the save/cancel button.
+
 To open a modal pathway in a template you can use the open-pathway directive:
 
 ```html
@@ -335,14 +337,13 @@ To open a modal pathway in a template you can use the open-pathway directive:
 
 the open-pathway directive also includes an optional call back, that is called with the context of the result of the modal.save method, ie episode_id, patient_id and redirect_url.
 
-To set a custom template only for the modal version of a class, set the modal_template_url variable.
-
-Pathways ships with a no footer modal template, the same as the normal modal template but it doesn't display the section at the bottom with the save/cancel button.
+By default the pathway is opened with whichever episode is on $scope.episode, you can use pathway-episode to define a different episode.
 
 e.g.
 
 ```html
-<a open-pathway="test_results" pathway-callback="refreshEpisode(episode_id)">open test results pathway</a>
+<a open-pathway="test_results"  pathway-episode="someOtherEpisode" pathway-callback="refreshEpisode(episode_id)">open test results pathway</a>
+
 ```
 
 

--- a/pathway/static/js/pathway/directives.js
+++ b/pathway/static/js/pathway/directives.js
@@ -123,6 +123,7 @@ directives.directive("openPathway", function($parse, $rootScope, Referencedata, 
         var pathwayCallback;
         $rootScope.state = "modal";
         var pathwaySlug = attrs.openPathway;
+        var episode = $parse(attrs.pathwayEpisode)(scope) || scope.episode;
         if(attrs.pathwayCallback){
           // we bind the parse to be able to use scope with us overriding
           // episode id in the function
@@ -142,7 +143,7 @@ directives.directive("openPathway", function($parse, $rootScope, Referencedata, 
           templateUrl: '/templates/pathway/pathway_detail.html',
           size       : 'lg',
           resolve    :  {
-            episode: function(){ return scope.episode; },
+            episode: function(){ return episode; },
             pathwaySlug: function(){ return pathwaySlug; },
             pathwayCallback: function(){ return pathwayCallback; }
           }

--- a/pathway/static/js/pathwaytest/directives.test.js
+++ b/pathway/static/js/pathwaytest/directives.test.js
@@ -52,6 +52,19 @@ describe('pathway directives', function(){
       scope.$digest();
       expect(_.partial).toHaveBeenCalledWith($parse("callback"), _, scope);
     });
+
+    it('should take the episode off pathway-episode parameter', function(){
+      scope.callback = jasmine.createSpy();
+      scope.onions = "trees";
+      spyOn(_, "partial");
+      var markup = '<a href="#" pathway-episode="onions" open-pathway="someSpy" pathway-callback="callback"></a>';
+      element = $compile(markup)(scope);
+      scope.$digest();
+      $(element).click();
+      scope.$digest();
+      var resolves = mockModal.open.calls.mostRecent().args[0].resolve;
+      expect(resolves.episode()).toBe('trees');
+    });
   });
 
 


### PR DESCRIPTION
…he open-pathway directive.

Does what it says on the tin.

for 4.0 I think we probably want to change this api a bit..

https://github.com/openhealthcare/opal-pathway/issues/100

points out that if we want to use a pathway to create a new episode that episode can't be on the scope at that point...

ie we need to always pass in the episode really... and at that point we need to ask whether we want these to be separate attributes or whether we want them to be {} style arguments